### PR TITLE
Replace deprecated template provider resources

### DIFF
--- a/groups/ois/cloud-init.tf
+++ b/groups/ois/cloud-init.tf
@@ -1,4 +1,4 @@
-data "template_cloudinit_config" "config" {
+data "cloudinit_config" "config" {
   count = var.instance_count
 
   gzip          = true

--- a/groups/ois/instance.tf
+++ b/groups/ois/instance.tf
@@ -99,7 +99,7 @@ resource "aws_instance" "ois" {
   subnet_id       = element(local.application_subnet_ids_by_az, count.index) # use 'element' function for wrap-around behaviour
 
   iam_instance_profile   = module.instance_profile.aws_iam_instance_profile.name
-  user_data_base64       = data.template_cloudinit_config.config[count.index].rendered
+  user_data_base64       = data.cloudinit_config.config[count.index].rendered
   vpc_security_group_ids = [aws_security_group.common.id]
 
   dynamic "ebs_block_device" {


### PR DESCRIPTION
The Terraform [template provider](https://registry.terraform.io/providers/hashicorp/template/latest/docs) has been deprecated and these changes replace resources belonging to the provider with [Cloud-init provider](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs) replacements.