### PR TITLE
Improve log rotation

### DIFF
--- a/roles/deploy/templates/logrotate.tuxedo.conf.j2
+++ b/roles/deploy/templates/logrotate.tuxedo.conf.j2
@@ -15,7 +15,6 @@
   daily
   copytruncate
   compress
-  maxage 93
   maxsize 1800M
   missingok
   notifempty
@@ -23,6 +22,10 @@
   rotate 20
   createolddir 0755 root root
   lastaction
-    /bin/find /var/log/tuxedo -maxdepth 2 \( -name 'ULOG.*' -o -name 'trlog.*' -o -name 'txlog.*' \) -mtime +1 -size 0 -delete
+    /bin/find {{ tuxedo_logs_path }} -name 'ULOG*.gz' -mtime +93 -exec rm -f {} \;
+    /bin/find {{ tuxedo_logs_path }} \( -name 'trlog.*' -o -name 'txlog.*' \) -mtime +93 -exec rm -f {} \;
+    /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'ULOG.*' -not -name "ULOG.$(date +%m%d%y)" -size 0 -delete
+    /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'txlog.*' -not -name "txlog.$(date +%d%m%y)" -size 0 -delete
+    /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'trlog.*' -not -name "trlog.$(date +%d%m%y)" -size 0 -delete
   endscript
 }

--- a/roles/deploy/templates/logrotate.tuxedo.conf.j2
+++ b/roles/deploy/templates/logrotate.tuxedo.conf.j2
@@ -23,7 +23,7 @@
   createolddir 0755 root root
   lastaction
     /bin/find {{ tuxedo_logs_path }} -name 'ULOG*.gz' -mtime +93 -exec rm -f {} \;
-    /bin/find {{ tuxedo_logs_path }} \( -name 'trlog.*' -o -name 'txlog.*' \) -mtime +7 -exec rm -f {} \;
+    /bin/find {{ tuxedo_logs_path }} \( -name 'trlog*.gz' -o -name 'txlog*.gz' \) -mtime +7 -exec rm -f {} \;
     /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'ULOG.*' -not -name "ULOG.$(date +%m%d%y)" -size 0 -delete
     /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'txlog.*' -not -name "txlog.$(date +%d%m%y)" -size 0 -delete
     /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'trlog.*' -not -name "trlog.$(date +%d%m%y)" -size 0 -delete

--- a/roles/deploy/templates/logrotate.tuxedo.conf.j2
+++ b/roles/deploy/templates/logrotate.tuxedo.conf.j2
@@ -23,7 +23,7 @@
   createolddir 0755 root root
   lastaction
     /bin/find {{ tuxedo_logs_path }} -name 'ULOG*.gz' -mtime +93 -exec rm -f {} \;
-    /bin/find {{ tuxedo_logs_path }} \( -name 'trlog.*' -o -name 'txlog.*' \) -mtime +93 -exec rm -f {} \;
+    /bin/find {{ tuxedo_logs_path }} \( -name 'trlog.*' -o -name 'txlog.*' \) -mtime +7 -exec rm -f {} \;
     /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'ULOG.*' -not -name "ULOG.$(date +%m%d%y)" -size 0 -delete
     /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'txlog.*' -not -name "txlog.$(date +%d%m%y)" -size 0 -delete
     /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'trlog.*' -not -name "trlog.$(date +%d%m%y)" -size 0 -delete


### PR DESCRIPTION
Improvements to log rotation and retention:

* Remove rotated `ULOG` files older than 93 days and `trlog`/`txlog` files older than 7 days
* Remove empty (i.e. already truncated) logs for any previous day excluding today