### PR TITLE
Add write policy action for CloudWatch metrics

### DIFF
--- a/groups/ois/iam.tf
+++ b/groups/ois/iam.tf
@@ -1,11 +1,22 @@
 module "instance_profile" {
   source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.99"
-  name = "${var.service_subtype}-${var.service}-profile"
+  name   = "${var.service_subtype}-${var.service}-profile"
 
-  cw_log_group_arns = [for log_group in merge(aws_cloudwatch_log_group.tuxedo, {"cloudwatch" = aws_cloudwatch_log_group.cloudwatch}) : "${log_group.arn}:*"]
-  enable_SSM = true
+  cw_log_group_arns = [for log_group in merge(aws_cloudwatch_log_group.tuxedo, { "cloudwatch" = aws_cloudwatch_log_group.cloudwatch }) : "${log_group.arn}:*"]
+  enable_SSM        = true
   kms_key_refs = [
     local.ssm_kms_key_id
   ]
   s3_buckets_write = [local.session_manager_bucket_name]
+
+  custom_statements = [
+    {
+      sid       = "CloudWatchMetricsWrite"
+      effect    = "Allow"
+      resources = ["*"]
+      actions = [
+        "cloudwatch:PutMetricData"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
These instance profile policy changes allow Tuxedo instances to write CloudWatch metrics for additional context when troubleshooting.

Resolves: `DVOP-2255`