### PR TITLE
Switch to Postfix mail transfer agent

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -17,7 +17,21 @@ cloudwatch_agent_defaults:
 getent_gid_index: 2
 getent_uid_index: 1
 
-smtp_mail_relay: smtp-outbound.sharedservices.aws.internal
+postfix_main_config_file: /etc/postfix/main.cf
+
+postfix_config:
+  - key: mydomain
+    value: companieshouse.gov.uk
+  - key: myorigin
+    value: $mydomain
+  - key: relayhost
+    value: smtp-outbound.sharedservices.aws.internal
+
+postfix_net_config:
+  - key: inet_interfaces
+    value: all
+  - key: inet_protocols
+    value: ipv4
 
 tuxedo_logs_path: /var/log/tuxedo
 tuxedo_log_rotation_config_path: /etc/logrotate.tuxedo.conf

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Restart Postfix service
+  systemd:
+    name: postfix
+    state: restarted
+    enabled: yes

--- a/roles/deploy/tasks/tools.yml
+++ b/roles/deploy/tasks/tools.yml
@@ -6,8 +6,30 @@
     name: mailx
     state: present
 
-- name: Configure mailx SMTP relay
-  lineinfile:
+- name: Disable mailx inbuilt SMTP relay
+  replace:
     path: /etc/mail.rc
-    regexp: '^set smtp='
-    line: 'set smtp={{ smtp_mail_relay }}'
+    regexp: '^(set smtp=.*)'
+    replace: '#\1'
+
+- name: Update Postfix configuration for mail relay (existing commented lines)
+  lineinfile:
+    dest: "{{ postfix_main_config_file }}"
+    line: "{{ item.key }} = {{ item.value }}"
+    regexp: "^#{{ item.key }} ="
+    insertafter: "^#{{ item.key }} ="
+  loop: "{{ postfix_config }}"
+  notify:
+    - Restart Postfix service
+
+- name: Update Postfix network config (existing uncommented lines)
+  lineinfile:
+    dest: "{{ postfix_main_config_file }}"
+    line: "{{ item.key }} = {{ item.value }}"
+    regexp: "^{{ item.key }} ="
+  loop: "{{ postfix_net_config }}"
+  notify:
+    - Restart Postfix service
+
+- name: Flush handlers
+  meta: flush_handlers


### PR DESCRIPTION
These changes replace the previously used SMTP functionality of `mailx` with the Postfix mail transfer agent and suitable configuration.