### PR TITLE
Fix for cron job mails being sent externally

### DIFF
--- a/roles/deploy/tasks/cron.yml
+++ b/roles/deploy/tasks/cron.yml
@@ -1,0 +1,29 @@
+
+- name: Create system cron job for log rotation
+  cron:
+    name: Log rotation for Tuxedo services
+    weekday: "*"
+    minute: "*/15"
+    hour: "*"
+    user: "root"
+    job: "logrotate {{ tuxedo_log_rotation_config_path }}"
+    cron_file: /etc/cron.d/log-rotation
+
+- name: Create maintenance job for periodic mail spool truncation
+  cron:
+    name: Periodic mail spool truncation
+    special_time: weekly
+    user: root
+    job: truncate -s 0 /var/spool/mail/*
+    cron_file: /etc/cron.d/mail-spool
+
+- name: Configure recipient addresses for system cron jobs
+  cronvar:
+    name: MAILTO
+    value: root@localhost
+    cron_file: "{{ item }}"
+  loop:
+    - /etc/crontab
+    - /etc/cron.d/clamav-update
+    - /etc/cron.d/log-rotation
+    - /etc/cron.d/mail-spool

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -194,6 +194,12 @@
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
 
+- name: "{{ tuxedo_user }} : Configure recipient address for user-specific cron job emails"
+  cronvar:
+    name: MAILTO
+    value: root@localhost
+    user: "{{ tuxedo_user }}"
+
 - name: "{{ tuxedo_user }} : Create CloudWatch agent configuration file for Tuxedo service group"
   template:
     src: templates/cloudwatch-config-service.json.j2

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -105,31 +105,7 @@
     src: templates/logrotate.tuxedo.conf.j2
     dest: "{{ tuxedo_log_rotation_config_path }}"
 
-- name: Create system cron job for log rotation
-  cron:
-    name: Log rotation for Tuxedo services
-    weekday: "*"
-    minute: "*/15"
-    hour: "*"
-    user: "root"
-    job: "logrotate {{ tuxedo_log_rotation_config_path }}"
-    cron_file: /etc/crontab
-
-- name: Configure recipient address for system cron job emails
-  cronvar:
-    name: MAILTO
-    value: root@localhost
-    cron_file: "{{ item }}"
-  loop:
-    - /etc/crontab
-    - /etc/cron.d/clamav-update
-
-- name: Create maintenance job for periodic mail spool truncation
-  cron:
-    name: Periodic mail spool truncation
-    special_time: weekly
-    cron_file: /etc/crontab
-    job: truncate -s 0 /var/spool/mail/*
+- import_tasks: cron.yml
 
 - name: Allow logrotate to modify CloudWatch log
   community.general.sefcontext:

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -115,7 +115,7 @@
     job: "logrotate {{ tuxedo_log_rotation_config_path }}"
     cron_file: /etc/crontab
 
-- name: Disable cron job output emails
+- name: Configure recipient address for system cron job emails
   cronvar:
     name: MAILTO
     value: root@localhost
@@ -126,9 +126,9 @@
 
 - name: Create maintenance job for periodic mail spool truncation
   cron:
-    name: Peridic mail spool truncation
+    name: Periodic mail spool truncation
     special_time: weekly
-    user: root
+    cron_file: /etc/crontab
     job: truncate -s 0 /var/spool/mail/*
 
 - name: Allow logrotate to modify CloudWatch log

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -118,11 +118,18 @@
 - name: Disable cron job output emails
   cronvar:
     name: MAILTO
-    value: ""
+    value: root@localhost
     cron_file: "{{ item }}"
   loop:
     - /etc/crontab
     - /etc/cron.d/clamav-update
+
+- name: Create maintenance job for periodic mail spool truncation
+  cron:
+    name: Peridic mail spool truncation
+    special_time: weekly
+    user: root
+    job: truncate -s 0 /var/spool/mail/*
 
 - name: Allow logrotate to modify CloudWatch log
   community.general.sefcontext:


### PR DESCRIPTION
This change fixes an issue whereby cron job output is being mailed to external accounts that may match valid inboxes, due to previous changes to the configuration of the mail transfer agent.