### PR TITLE
Use canonical YAML truthy values

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,9 +1,9 @@
 [defaults]
-host_key_checking = False
+host_key_checking = false
 timeout = 60
 
 [inventory]
 enable_plugins = aws_ec2
 
 [ssh_connection]
-pipelining = True
+pipelining = true

--- a/deploy.yml
+++ b/deploy.yml
@@ -12,6 +12,6 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: deploy

--- a/group_vars/tag_Environment_live.yml
+++ b/group_vars/tag_Environment_live.yml
@@ -1,11 +1,11 @@
 ---
 
 alerts:
-  enabled: yes
+  enabled: true
   vault_path: "/applications/heritage-live-eu-west-2/ois-tuxedo/alerts"
 
 stats:
-  enabled: yes
+  enabled: true
   vault_path: "/applications/heritage-live-eu-west-2/ois-tuxedo/stats"
 
 cloudwatch_agent_overrides:

--- a/nfs.yml
+++ b/nfs.yml
@@ -12,6 +12,6 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: nfs-mounts

--- a/roles/deploy/README.md
+++ b/roles/deploy/README.md
@@ -93,16 +93,16 @@ During execution of this role, cron jobs are temporarily disabled to avoid gener
 
 Several of the scripts that are executed as [maintenance jobs][5] will generate email alerts dependent upon certain conditions. Alerts are _disabled_ by default and generally enabled only for the production environment. To enable alerts, define an `alerts` group variable as a dictionary with the following parameters:
 
-| Name                 | Default | Description                                                      |
-|----------------------|---------|------------------------------------------------------------------|
-| `enabled`            | `no`    | The boolean value `yes` (to override the default value of `no`). |
-| `vault_path`         |         | The path to the alerting configuration in Hashicorp Vault.       |
+| Name                 | Default   | Description                                                |
+|----------------------|-----------|------------------------------------------------------------|
+| `enabled`            | `false`   | A boolean value indicating whether to enable alerts.       |
+| `vault_path`         |           | The path to the alerting configuration in Hashicorp Vault. |
 
 For example, to enable email alerts for the production environment add the following group variable:
 
 ```yaml
 alerts:
-  enabled: yes
+  enabled: true
   vault_path: "/applications/heritage-live-eu-west-2/ois-tuxedo/alerts"
 ```
 
@@ -121,16 +121,16 @@ A JSON document should be added to Hashicorp Vault at the path specified by `vau
 
 Scripts that are executed as [maintenance jobs][5] may generate statistics that require transfer to remote hosts for further processing. This is _disabled_ by default and generally enabled only for the production environment. To enable this, define a `stats` group variable as a dictionary with the following parameters:
 
-| Name                 | Default | Description                                                      |
-|----------------------|---------|------------------------------------------------------------------|
-| `enabled`            | `no`    | The boolean value `yes` (to override the default value of `no`). |
-| `vault_path`         |         | The path to the alerting configuration in Hashicorp Vault.       |
+| Name                 | Default | Description                                                         |
+|----------------------|---------|---------------------------------------------------------------------|
+| `enabled`            | `false` | A boolean value indicating whether to enable statistics generation. |
+| `vault_path`         |         | The path to the alerting configuration in Hashicorp Vault.          |
 
 For example, to enable statistics for the production environment add the following group variable:
 
 ```yaml
 alerts:
-  enabled: yes
+  enabled: true
   vault_path: "/applications/heritage-live-eu-west-2/ois-tuxedo/stats"
 ```
 

--- a/roles/deploy/README.md
+++ b/roles/deploy/README.md
@@ -93,10 +93,10 @@ During execution of this role, cron jobs are temporarily disabled to avoid gener
 
 Several of the scripts that are executed as [maintenance jobs][5] will generate email alerts dependent upon certain conditions. Alerts are _disabled_ by default and generally enabled only for the production environment. To enable alerts, define an `alerts` group variable as a dictionary with the following parameters:
 
-| Name                 | Default   | Description                                                |
-|----------------------|-----------|------------------------------------------------------------|
-| `enabled`            | `false`   | A boolean value indicating whether to enable alerts.       |
-| `vault_path`         |           | The path to the alerting configuration in Hashicorp Vault. |
+| Name                 | Default   | Description                                                 |
+|----------------------|-----------|-------------------------------------------------------------|
+| `enabled`            | `false`   | A boolean value indicating whether to enable alerts or not. |
+| `vault_path`         |           | The path to the alerting configuration in Hashicorp Vault.  |
 
 For example, to enable email alerts for the production environment add the following group variable:
 
@@ -121,10 +121,10 @@ A JSON document should be added to Hashicorp Vault at the path specified by `vau
 
 Scripts that are executed as [maintenance jobs][5] may generate statistics that require transfer to remote hosts for further processing. This is _disabled_ by default and generally enabled only for the production environment. To enable this, define a `stats` group variable as a dictionary with the following parameters:
 
-| Name                 | Default | Description                                                         |
-|----------------------|---------|---------------------------------------------------------------------|
-| `enabled`            | `false` | A boolean value indicating whether to enable statistics generation. |
-| `vault_path`         |         | The path to the alerting configuration in Hashicorp Vault.          |
+| Name                 | Default | Description                                                                |
+|----------------------|---------|----------------------------------------------------------------------------|
+| `enabled`            | `false` | A boolean value indicating whether to enable statistics generation or not. |
+| `vault_path`         |         | The path to the alerting configuration in Hashicorp Vault.                 |
 
 For example, to enable statistics for the production environment add the following group variable:
 

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
 
 alerts:
-  enabled: no
+  enabled: false
 
 stats:
-  enabled: no
+  enabled: false
 
 cloudwatch_agent_defaults:
   path: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -4,4 +4,4 @@
   systemd:
     name: postfix
     state: restarted
-    enabled: yes
+    enabled: true

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -19,7 +19,7 @@
     tuxedo_user_id: "{{ getent_passwd[tuxedo_user][getent_uid_index] }}"
     tuxedo_queue_path: "/home/{{ tuxedo_user }}/queues/{{ tuxedo_queue_space_device }}"
     tuxedo_log_size: "{{ tuxedo_service_config[tuxedo_user].tuxedo_log_size }}"
-  no_log: True
+  no_log: true
 
 - name: Retrieve alerts config from Hashicorp Vault
   set_fact:
@@ -73,7 +73,7 @@
     mode: 0644
   with_fileglob:
     - "{{ application_configs_path }}/{{ tuxedo_user }}/*.j2"
-  no_log: True
+  no_log: true
 
 - name: "{{ tuxedo_user }} : Create scripts directory"
   file:
@@ -204,7 +204,7 @@
   template:
     src: templates/cloudwatch-config-service.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config-{{ tuxedo_user }}.json"
-    trim_blocks: False
+    trim_blocks: false
 
 - name: "{{ tuxedo_user }} : Check state of {{ tuxedo_user }} queue"
   stat:

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -98,7 +98,7 @@
     path: "{{ new_deployment_files.path }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    recurse: yes
+    recurse: true
 
 - name: "{{ tuxedo_user }} : Check state of {{ tuxedo_user }} current deployment directory"
   stat:
@@ -110,7 +110,7 @@
   shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/mncq_stop"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: tuxedo_user != "ceu"
 
 - name: "{{ tuxedo_user }} : Stop packq daemon processes"
@@ -118,7 +118,7 @@
   shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/packq_stop"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: tuxedo_user != "ceu" and tuxedo_user != "xml"
 
 - name: "{{ tuxedo_user }} : Stop Tuxedo services"
@@ -126,7 +126,7 @@
   shell: "source {{ tuxedo_env_file_path }} && timeout -s 9 20 tmshutdown -y"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: current_deployment_files.stat.exists
 
 - name: "{{ tuxedo_user }} : Clear IPC facilities"
@@ -253,7 +253,7 @@
   shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/mncq_start"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: tuxedo_user != "ceu"
 
 - name: "{{ tuxedo_user }} : Start packq daemon processes"
@@ -261,7 +261,7 @@
   shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/packq_start"
   args:
     executable: /bin/bash
-  ignore_errors: yes
+  ignore_errors: true
   when: tuxedo_user != "ceu" and tuxedo_user != "xml"
 
 - name: "{{ tuxedo_user }} : Create maintenance jobs"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -50,7 +50,7 @@
   template:
     src: templates/cloudwatch-config.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
-    trim_blocks: False
+    trim_blocks: false
 
 - name: Start CloudWatch agent using primary configuration file
   command:

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -80,7 +80,7 @@
   unarchive:
     src: "{{ application_artifact_path }}"
     dest: "{{ application_artifact_files.path }}"
-    remote_src: no
+    remote_src: false
     owner: root
     group: "{{ tuxedo_service_group }}"
     mode: 0755


### PR DESCRIPTION
These changes ensure that truthy values are represented using canonical [YAML boolean form](https://yaml.org/spec/1.2.1/#id2803629) in accordance with recent [Ansible documentation updates](https://github.com/ansible/ansible/pull/78429) and will suppress `yamllint` warnings.