### PR TITLE
Bump ansible-role-nfs-mounts version

### DIFF
--- a/group_vars/tag_Environment_live.yml
+++ b/group_vars/tag_Environment_live.yml
@@ -19,7 +19,6 @@ nfs_mounts_config:
   - path: "/data1/apps/scud"
     src: "192.168.255.35:/scanning"
     symlink: "/scanning"
-    fstype: "nfs4"
 
 maintenance_jobs:
   xml:

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,7 +6,7 @@ roles:
     version: "1.0.0"
   - src: https://github.com/companieshouse/ansible-role-nfs-mounts
     name: nfs-mounts
-    version: "1.0.2"
+    version: "1.1.0"
 
 collections:
 - name: amazon.aws


### PR DESCRIPTION
This change ensures that we inherit the default `nfsvers=4` option for `fstab` NFS mount entries ensuring use of version 4 of the NFS protocol and removes the [deprecated `nfs4` fstab option](https://www.systutorials.com/docs/linux/man/5-nfs/).