### PR TITLE
Refactor deploy role

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,4 @@
+---
+# .ansible-lint
+
+profile: production

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,1 @@
+roles/deploy/defaults/main.yml var-naming[no-role-prefix]

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,18 +1,18 @@
 ---
 
-# Provision Ansible controller with SSH key for remote
-- hosts: localhost
+- name: Provision Ansible controller with SSH key for remote
+  hosts: localhost
   roles:
-    - role: ssh-key
+    - role: companieshouse.general.ssh_key
       vars:
         ssh_key_name: ansible_remote
-        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
+        ssh_key_vault_path: "{{ vault_base_path }}/aws"
 
-# Deploy Tuxedo services
-- hosts: aws_ec2
+- name: Deploy Tuxedo services
+  hosts: aws_ec2
   serial: 1
   remote_user: centos
   become: true
   roles:
-    - role: systemd-journald
+    - role: companieshouse.general.systemd_journald
     - role: deploy

--- a/nfs.yml
+++ b/nfs.yml
@@ -1,15 +1,15 @@
 ---
 
-# Provision Ansible controller with SSH key for remote
-- hosts: localhost
+- name: Provision Ansible controller with SSH key for remote
+  hosts: localhost
   roles:
-    - role: ssh-key
+    - role: companieshouse.general.ssh_key
       vars:
         ssh_key_name: ansible_remote
-        hashicorp_vault_private_key_path: "{{ vault_base_path }}/aws"
+        ssh_key_vault_path: "{{ vault_base_path }}/aws"
 
-# Provision NFS mounts
-- hosts: aws_ec2
+- name: Provision NFS mounts
+  hosts: aws_ec2
   serial: 1
   remote_user: centos
   become: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,20 +1,14 @@
 ---
 
 roles:
-  - src: https://github.com/companieshouse/ansible-role-ssh-key
-    name: ssh-key
-    version: "1.0.0"
   - src: https://github.com/companieshouse/ansible-role-nfs-mounts
     name: nfs-mounts
     version: "1.1.0"
-  - src: "https://github.com/companieshouse/ansible-role-systemd-journald"
-    name: systemd-journald
-    version: "1.0.0"
 
 collections:
-- name: amazon.aws
-  version: "4.2.0"
-- name: community.general
-  version: "4.8.0"
-- name: community.hashi_vault
-  version: "3.3.1"
+  - name: amazon.aws
+    version: "8.1.0"
+  - name: community.general
+    version: "9.3.0"
+  - name: companieshouse.general
+    version: "1.0.1"

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -123,7 +123,7 @@ tuxedo_service_config:
     ipc_key: "{{ tuxedo_service_ipc_key_start + (2 * tuxedo_service_ipc_key_increment) | int }}"
     local_domain_port: "{{ tuxedo_service_domain_port_start + (2 * tuxedo_service_domain_port_increment) | int }}"
     queue_space_ipc_key: "{{ tuxedo_queue_space_ipc_key_start + (2 * tuxedo_queue_space_ipc_key_increment) | int }}"
-    queue_space_2_ipc_key: "{{ tuxedo_queue_space_ipc_key_start + (2 * tuxedo_queue_space_ipc_key_increment) +  1 | int }}"
+    queue_space_2_ipc_key: "{{ tuxedo_queue_space_ipc_key_start + (2 * tuxedo_queue_space_ipc_key_increment) + 1 | int }}"
     tuxedo_log_size: 10
   xml:
     ipc_key: "{{ tuxedo_service_ipc_key_start + (3 * tuxedo_service_ipc_key_increment) | int }}"

--- a/roles/deploy/handlers/main.yml
+++ b/roles/deploy/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Restart Postfix service
-  systemd:
+  ansible.builtin.systemd:
     name: postfix
     state: restarted
     enabled: true

--- a/roles/deploy/tasks/cron.yml
+++ b/roles/deploy/tasks/cron.yml
@@ -1,6 +1,7 @@
+---
 
 - name: Create system cron job for log rotation
-  cron:
+  ansible.builtin.cron:
     name: Log rotation for Tuxedo services
     weekday: "*"
     minute: "*/15"
@@ -10,7 +11,7 @@
     cron_file: /etc/cron.d/log-rotation
 
 - name: Create maintenance job for periodic mail spool truncation
-  cron:
+  ansible.builtin.cron:
     name: Periodic mail spool truncation
     special_time: weekly
     user: root
@@ -18,7 +19,7 @@
     cron_file: /etc/cron.d/mail-spool
 
 - name: Configure recipient addresses for system cron jobs
-  cronvar:
+  community.general.cronvar:
     name: MAILTO
     value: root@localhost
     cron_file: "{{ item }}"
@@ -30,7 +31,7 @@
     - /etc/cron.d/mail-spool
 
 - name: Configure recipient addresses for system anacron jobs
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/anacrontab
     regexp: '^MAILTO='
     line: MAILTO=root@localhost

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: "{{ tuxedo_user }} : Set additional variables for template population"
-  set_fact:
+- name: "Set additional variables for template population : {{ tuxedo_user }}"
+  ansible.builtin.set_fact:
     orders_min_boot_count: "{{ tuxedo_service_config[tuxedo_user].orders_min_boot_count | default(8) }}"
     private_host_address: "{{ inventory_hostname }}"
     private_host_local_domain_port: "{{ tuxedo_service_config[tuxedo_user].local_domain_port }}"
@@ -21,251 +21,288 @@
     tuxedo_log_size: "{{ tuxedo_service_config[tuxedo_user].tuxedo_log_size }}"
   no_log: true
 
-- name: "{{ tuxedo_user }} : Retrieve alerts config from Hashicorp Vault"
-  set_fact:
+- name: "Retrieve alerts config from Hashicorp Vault : {{ tuxedo_user }}"
+  ansible.builtin.set_fact:
     alerts_config: "{{ lookup('community.hashi_vault.hashi_vault', alerts.vault_path) }}"
   when: alerts.enabled
 
-- name: "{{ tuxedo_user }} : Retrieve stats config from Hashicorp Vault"
-  set_fact:
+- name: "Retrieve stats config from Hashicorp Vault : {{ tuxedo_user }}"
+  ansible.builtin.set_fact:
     stats_config: "{{ lookup('community.hashi_vault.hashi_vault', stats.vault_path) }}"
   when: stats.enabled
 
-- name: "{{ tuxedo_user }} : Remove maintenance jobs during deploy"
-  cron:
-    name: "{{ item.name }}"
-    user: "{{ tuxedo_user }}"
+- name: "Remove maintenance jobs during deploy : {{ tuxedo_user }}"
+  ansible.builtin.file:
+    path: "/var/spool/cron/{{ tuxedo_user }}"
     state: absent
-  loop: "{{ maintenance_jobs[tuxedo_user] | default([]) }}"
 
-- name: "{{ tuxedo_user }} : Create temporary directory for new {{ tuxedo_user }} deployment"
+- name: "Create temporary directory for new deployment : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
   register: new_deployment_files
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Copy application artifact files to temporary {{ tuxedo_user }} deployment directory"
+- name: "Copy application artifact files to temporary deployment directory : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  command: "cp -r {{ application_artifact_files.path }}/. {{ new_deployment_files.path }}"
+  ansible.builtin.command: "cp -r {{ application_artifact_files.path }}/. {{ new_deployment_files.path }}"
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Create service logs directory"
-  file:
+- name: "Create Tuxedo service logs directory : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ tuxedo_logs_path }}/{{ tuxedo_user }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
-- name: "{{ tuxedo_user }} : Create config directory"
-  file:
+- name: "Create config directory : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ new_deployment_files.path }}/config"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
-- name: "{{ tuxedo_user }} : Populate template config files"
-  template:
+- name: "Populate Tuxedo template config files : {{ tuxedo_user }}"
+  ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ new_deployment_files.path }}/config/{{ item | basename | replace('.j2', '') }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0644
+    mode: '0644'
   with_fileglob:
     - "{{ application_configs_path }}/{{ tuxedo_user }}/*.j2"
   no_log: true
 
-- name: "{{ tuxedo_user }} : Create scripts directory"
-  file:
+- name: "Create scripts directory : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ new_deployment_files.path }}/scripts"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
-- name: "{{ tuxedo_user }} : Populate script template files"
-  template:
+- name: "Populate script template files : {{ tuxedo_user }}"
+  ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ new_deployment_files.path }}/scripts/{{ item | basename | replace('.j2', '') }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0755
+    mode: '0755'
   with_fileglob:
     - "{{ scripts_artifact_path }}/*.j2"
 
-- name: "{{ tuxedo_user }} : Set permissions for new deployment files"
-  file:
+- name: "Set permissions for new deployment files : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "{{ new_deployment_files.path }}"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
     recurse: true
 
-- name: "{{ tuxedo_user }} : Check state of {{ tuxedo_user }} current deployment directory"
-  stat:
+- name: "Check state of current deployment directory : {{ tuxedo_user }}"
+  ansible.builtin.stat:
     path: "/home/{{ tuxedo_user }}/{{ deployment_dir }}"
   register: current_deployment_files
 
-- name: "{{ tuxedo_user }} : Stop mncq daemon processes"
+- name: "Stop mncq daemon processes : {{ tuxedo_user }}" # noqa ignore-errors
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/mncq_stop"
+  register: stop_mncq_daemon
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/mncq_stop"
   args:
     executable: /bin/bash
   ignore_errors: true
   when: tuxedo_user != "ceu"
+  changed_when: "'mncq daemon stopped' in stop_mncq_daemon.stdout and stop_mncq_daemon.rc == 0"
 
-- name: "{{ tuxedo_user }} : Stop packq daemon processes"
+- name: "Stop packq daemon processes : {{ tuxedo_user }}" # noqa ignore-errors
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/packq_stop"
+  register: stop_packq_daemon
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/packq_stop"
   args:
     executable: /bin/bash
   ignore_errors: true
   when: tuxedo_user != "ceu" and tuxedo_user != "xml"
+  changed_when: "'packq daemon stopped' in stop_packq_daemon.stdout and stop_packq_daemon.rc == 0"
 
-- name: "{{ tuxedo_user }} : Stop Tuxedo services"
+- name: "Stop Tuxedo services : {{ tuxedo_user }}" # noqa ignore-errors
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && timeout -s 9 20 tmshutdown -y"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && timeout -s 9 20 tmshutdown -y"
   args:
     executable: /bin/bash
   ignore_errors: true
   when: current_deployment_files.stat.exists
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Clear IPC facilities"
+- name: "Clear IPC facilities : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && zapipc"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && zapipc"
   args:
     executable: /bin/bash
   when: current_deployment_files.stat.exists
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Remove {{ tuxedo_user }} rollback directory if present"
-  file:
+- name: "Remove rollback directory if present : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "/home/{{ tuxedo_user }}/{{ rollback_dir }}"
     state: absent
 
-- name: "{{ tuxedo_user }} : Backup {{ tuxedo_user }} current deployment directory if one exists"
+- name: "Backup current deployment directory if one exists : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  command: "mv /home/{{ tuxedo_user }}/{{ deployment_dir }} /home/{{ tuxedo_user }}/{{ rollback_dir }}"
+  ansible.builtin.command: "mv /home/{{ tuxedo_user }}/{{ deployment_dir }} /home/{{ tuxedo_user }}/{{ rollback_dir }}"
   when: current_deployment_files.stat.exists
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Install new deployment files"
+- name: "Install new deployment files : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  command: "mv {{ new_deployment_files.path }} /home/{{ tuxedo_user }}/{{ deployment_dir }}"
+  ansible.builtin.command: "mv {{ new_deployment_files.path }} /home/{{ tuxedo_user }}/{{ deployment_dir }}"
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Lint Tuxedo ubbconfig file after variable population"
+- name: "Lint Tuxedo ubbconfig file after variable population : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && tmloadcf -n ubbconfig"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && tmloadcf -n ubbconfig"
   args:
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
   register: ubbconfig_lint
+  changed_when: false
 
-- name: "{{ tuxedo_user }} : Assert Tuxedo ubbconfig lint success"
-  assert:
+- name: "Assert Tuxedo ubbconfig lint success : {{ tuxedo_user }}"
+  ansible.builtin.assert:
     that:
       - ubbconfig_lint.rc == 0
     fail_msg: "Tuxedo ubbconfig file failed lint check"
     success_msg: "Tuxedo ubbconfig file passed lint check"
 
-- name: "{{ tuxedo_user }} : Generate Tuxedo binary tuxconfig file"
+- name: "Generate Tuxedo binary tuxconfig file : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && tmloadcf -y ubbconfig"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && tmloadcf -y ubbconfig"
   args:
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Lint Tuxedo dmconfig file after variable population"
+- name: "Lint Tuxedo dmconfig file after variable population : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && dmloadcf -n dmconfig"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && dmloadcf -n dmconfig"
   args:
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
   register: dmconfig_lint
+  changed_when: false
 
-- name: "{{ tuxedo_user }} : Assert Tuxedo dmconfig lint success"
-  assert:
+- name: "Assert Tuxedo dmconfig lint success : {{ tuxedo_user }}"
+  ansible.builtin.assert:
     that:
       - dmconfig_lint.rc == 0
     fail_msg: "Tuxedo dmconfig file failed lint check"
     success_msg: "Tuxedo dmconfig file passed lint check"
 
-- name: "{{ tuxedo_user }} : Generate Tuxedo binary bdmconfig file"
+- name: "Generate Tuxedo binary bdmconfig file : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && dmloadcf -y dmconfig"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && dmloadcf -y dmconfig"
   args:
     chdir: "/home/{{ tuxedo_user }}/{{ deployment_dir }}/config"
     executable: /bin/bash
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Configure recipient address for user-specific cron job emails"
-  cronvar:
+- name: "Configure recipient address for user-specific cron job emails : {{ tuxedo_user }}"
+  community.general.cronvar:
     name: MAILTO
     value: root@localhost
     user: "{{ tuxedo_user }}"
 
-- name: "{{ tuxedo_user }} : Create CloudWatch agent configuration file for Tuxedo service group"
-  template:
+- name: "Create CloudWatch agent configuration file for Tuxedo service group : {{ tuxedo_user }}"
+  ansible.builtin.template:
     src: templates/cloudwatch-config-service.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config-{{ tuxedo_user }}.json"
+    owner: cwagent
+    group: cwagent
+    mode: '0644'
     trim_blocks: false
 
-- name: "{{ tuxedo_user }} : Check state of {{ tuxedo_user }} queue"
-  stat:
+- name: "Check state of queue : {{ tuxedo_user }}"
+  ansible.builtin.stat:
     path: "/home/{{ tuxedo_user }}/queues/{{ tuxedo_queue_space_device }}"
   register: queue
 
-- name: "{{ tuxedo_user }} : Create queues directory"
-  file:
+- name: "Create queues directory : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "/home/{{ tuxedo_user }}/queues"
     state: directory
-    mode: 0755
+    mode: '0755'
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
 
-- name: "{{ tuxedo_user }} : Deploy queue creation script"
-  template:
+- name: "Deploy queue creation script : {{ tuxedo_user }}"
+  ansible.builtin.template:
     src: "create_{{ tuxedo_user }}_queue.j2"
     dest: "/home/{{ tuxedo_user }}/create_{{ tuxedo_user }}_queue"
     owner: "{{ tuxedo_user }}"
     group: "{{ tuxedo_user }}"
-    mode: 0777
+    mode: '0777'
   when: not queue.stat.exists
 
-- name: "{{ tuxedo_user }} : Create universal device entry, queue space, and queues"
+- name: "Create universal device entry, queue space, and queues : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && ./create_{{ tuxedo_user }}_queue"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && ./create_{{ tuxedo_user }}_queue"
   args:
     chdir: "/home/{{ tuxedo_user }}"
     executable: /bin/bash
   when: not queue.stat.exists
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Remove queue creation script"
-  file:
+- name: "Remove queue creation script : {{ tuxedo_user }}"
+  ansible.builtin.file:
     path: "/home/{{ tuxedo_user }}/create_{{ tuxedo_user }}_queue"
     state: absent
   when: not queue.stat.exists
 
-- name: "{{ tuxedo_user }} : Start Tuxedo services"
+- name: "Start Tuxedo services : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source /home/{{ tuxedo_user }}/{{ deployment_dir }}/config/envfile && tmboot -y"
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && tmboot -y"
   args:
     executable: /bin/bash
+  changed_when: true
 
-- name: "{{ tuxedo_user }} : Start mncq daemon processes"
+- name: "Start mncq daemon processes : {{ tuxedo_user }}" # noqa ignore-errors
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/mncq_start"
+  register: start_mncq_daemon
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/mncq_start"
   args:
     executable: /bin/bash
   ignore_errors: true
   when: tuxedo_user != "ceu"
+  changed_when: "start_mncq_daemon.rc == 0"
 
-- name: "{{ tuxedo_user }} : Start packq daemon processes"
+- name: "Start packq daemon processes : {{ tuxedo_user }}"
+  become: true
   become_user: "{{ tuxedo_user }}"
-  shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/packq_start"
+  register: start_packq_daemon
+  ansible.builtin.shell: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/packq_start"
   args:
     executable: /bin/bash
   ignore_errors: true
   when: tuxedo_user != "ceu" and tuxedo_user != "xml"
+  changed_when: "start_packq_daemon.rc == 0"
 
-- name: "{{ tuxedo_user }} : Create maintenance jobs"
-  cron:
+- name: "Create maintenance jobs : {{ tuxedo_user }}"
+  ansible.builtin.cron:
     name: "{{ item.name }}"
     day: "{{ item.day_of_month }}"
     weekday: "{{ item.day_of_week }}"
@@ -273,5 +310,6 @@
     hour: "{{ item.hour }}"
     month: "{{ item.month }}"
     user: "{{ tuxedo_user }}"
-    job: "source /home/{{ tuxedo_user }}/{{ deployment_dir }}/config/envfile && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/{{ item.script }}"
+    job: "source {{ tuxedo_env_file_path }} && /home/{{ tuxedo_user }}/{{ deployment_dir }}/scripts/{{ item.script }}"
+    disabled: "{{ item.disabled | default(false) }}"
   loop: "{{ maintenance_jobs[tuxedo_user] | default([]) }}"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -4,11 +4,11 @@
   amazon.aws.ec2_metadata_facts:
 
 - name: Set host facts for passwd database
-  getent:
+  ansible.builtin.getent:
     database: passwd
 
 - name: Check required variables are set
-  assert:
+  ansible.builtin.assert:
     that:
       - tuxedo_service_users is defined and tuxedo_service_users | length > 0
       - environment_name is defined and environment_name | trim | length > 0
@@ -18,43 +18,54 @@
     msg: "Required variable(s) empty or undefined"
 
 - name: Check valid combination of services for deployment
-  fail:
+  ansible.builtin.fail:
     msg: Deploy 'ois' services exclusively, or any combination of 'ceu', 'xml' or 'publ', not both
   when: tuxedo_service_users | length > 1 and 'ois' in tuxedo_service_users
 
 - name: Check valid combination of services for development or staging environment
-  fail:
+  ansible.builtin.fail:
     msg: Cannot deploy services other than 'ois' to this environment
-  when:  environment_name != "live" and "ois" not in tuxedo_service_users
+  when: environment_name != "live" and "ois" not in tuxedo_service_users
 
 - name: Check valid combination of services for live
-  fail:
+  ansible.builtin.fail:
     msg: Cannot deploy 'ois' services to live; this is intended for development or staging only
-  when:  environment_name == "live" and "ois" in tuxedo_service_users
+  when: environment_name == "live" and "ois" in tuxedo_service_users
+
+- name: Set common Tuxedo fact for domain suffix
+  ansible.builtin.set_fact:
+    tuxedo_common_suffix: "{{ ansible_facts.hostname
+      | regex_replace('development', 'dev')
+      | regex_replace('^ois-tuxedo-([A-Za-z]+)-(\\d+)$', 'INSTANCE_\\2_\\1')
+      | upper }}"
 
 # The hostname is assumed to be in the format: ois-tuxedo-<environment>-<instance-index>; the environment
 # name 'development' is abbreviated to 'dev' to avoid exceeding the domain character limit
 - name: Set Tuxedo facts for config population
-  set_fact:
-     tuxedo_domain_id_suffix: "{{ ansible_facts.hostname | regex_replace('development', 'dev') | regex_replace('^ois-tuxedo-([A-Za-z].*)-(\\d+)$', 'INSTANCE_\\2_\\1_DOM') | upper }}"
-     tuxedo_logical_machine_id_suffix: "{{ ansible_facts.hostname | regex_replace('development', 'dev') | regex_replace('^ois-tuxedo-([A-Za-z].*)-(\\d+)$', 'INSTANCE_\\2_\\1_SRV') | upper }}"
-     tuxedo_local_domain_suffix: "{{ ansible_facts.hostname | regex_replace('development', 'dev') | regex_replace('^ois-tuxedo-([A-Za-z].*)-(\\d+)$', 'INSTANCE_\\2_\\1_LOD') | upper }}"
+  ansible.builtin.set_fact:
+    tuxedo_domain_id_suffix: "{{ tuxedo_common_suffix + '_DOM' }}"
+    tuxedo_logical_machine_id_suffix: "{{ tuxedo_common_suffix + '_SRV' }}"
+    tuxedo_local_domain_suffix: "{{ tuxedo_common_suffix + '_LOD' }}"
 
 - name: Set CloudWatch agent facts for config population
-  set_fact:
+  ansible.builtin.set_fact:
     cloudwatch_agent: "{{ cloudwatch_agent_defaults | combine(cloudwatch_agent_overrides | default({})) }}"
     cloudwatch_log_stream_name: "{{ ansible_ec2_instance_id }}_{{ ansible_ec2_hostname }}"
     region: "{{ ansible_ec2_instance_identity_document_region }}"
 
 - name: Create CloudWatch agent primary configuration file
-  template:
+  ansible.builtin.template:
     src: templates/cloudwatch-config.json.j2
     dest: "{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
+    owner: cwagent
+    group: cwagent
+    mode: '0644'
     trim_blocks: false
 
 - name: Start CloudWatch agent using primary configuration file
-  command:
+  ansible.builtin.command:
     cmd: "{{ cloudwatch_agent.path }} -a fetch-config -m ec2 -s -c file:{{ cloudwatch_agent.config_dir }}/cloudwatch-config.json"
+  changed_when: true
 
 - name: Using constructed variable suffixes
   ansible.builtin.debug:
@@ -65,85 +76,86 @@
     - tuxedo_local_domain_suffix
 
 - name: Create temporary directory for application artifact files
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
   register: application_artifact_files
 
 - name: Set permissions to allow service users to read from temporary directory
-  file:
+  ansible.builtin.file:
     path: "{{ application_artifact_files.path }}"
     owner: root
     group: "{{ tuxedo_service_group }}"
-    mode: 0755
+    mode: '0755'
 
-- name: Deploy and extract application arterfact
-  unarchive:
+- name: Deploy and extract application artefact
+  ansible.builtin.unarchive:
     src: "{{ application_artifact_path }}"
     dest: "{{ application_artifact_files.path }}"
     remote_src: false
     owner: root
     group: "{{ tuxedo_service_group }}"
-    mode: 0755
+    mode: '0755'
 
 - name: Create Tuxedo logs directory
-  file:
+  ansible.builtin.file:
     path: "{{ tuxedo_logs_path }}"
     owner: root
     group: "{{ tuxedo_service_group }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
 - name: Create OIS stats directory on shared NFS mount
-  file:
+  ansible.builtin.file:
     path: /scanning/ois-stats
     owner: root
     group: root
-    mode: 0777
+    mode: '0777'
     state: directory
 
 - name: Create shared log rotation configuration for Tuxedo services
-  template:
+  ansible.builtin.template:
     src: templates/logrotate.tuxedo.conf.j2
     dest: "{{ tuxedo_log_rotation_config_path }}"
+    owner: root
+    group: root
+    mode: '0644'
 
-- import_tasks: cron.yml
+- name: Configure cron jobs
+  ansible.builtin.import_tasks: cron.yml
 
-- name: Allow logrotate to modify CloudWatch log
+- name: Allow logrotate to modify CloudWatch logs
   community.general.sefcontext:
-    target: "{{ item }}"
+    target: '/opt/aws/amazon-cloudwatch-agent/logs(/.*)?'
     setype: var_log_t
     state: present
-  loop:
-    - /opt/aws/amazon-cloudwatch-agent/logs
-    - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
-  register: selinux_context
 
-- name: Apply SELinux file context for CloudWatch log
-  command: "restorecon {{ item }}"
-  loop:
-    - /opt/aws/amazon-cloudwatch-agent/logs
-    - /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
-  when: selinux_context.changed
+- name: Update SELinux security context
+  ansible.builtin.command: "restorecon -irv /opt/aws/amazon-cloudwatch-agent/logs"
+  register: cloudwatch_logs_selinux_context
+  changed_when: cloudwatch_logs_selinux_context.stdout != ""
 
-- import_tasks: tools.yml
+- name: Install additional tooling
+  ansible.builtin.import_tasks: tools.yml
 
-- include_tasks: deploy.yml
+- name: Deploy Tuxedo services
+  ansible.builtin.include_tasks: deploy.yml
   loop: "{{ tuxedo_service_users }}"
   loop_control:
     loop_var: tuxedo_user
 
 - name: Find application-specific CloudWatch configuration files
-  find:
+  ansible.builtin.find:
     paths: "{{ cloudwatch_agent.config_dir }}"
     patterns: 'cloudwatch-config-*.json'
   register: cloudwatch_configs
 
 - name: Add configuration for Tuxedo service group to CloudWatch agent
-  command:
+  ansible.builtin.command:
     cmd: "{{ cloudwatch_agent.path }} -a append-config -m ec2 -s -c file:{{ item.path }}"
   loop: "{{ cloudwatch_configs.files }}"
+  changed_when: true
 
 - name: Remove temporary directories
-  file:
+  ansible.builtin.file:
     path: "{{ application_artifact_files.path }}"
     state: absent

--- a/roles/deploy/tasks/tools.yml
+++ b/roles/deploy/tasks/tools.yml
@@ -1,26 +1,25 @@
-
 ---
 
-- name: Install mailx mail processing system
-  yum:
+- name: Install mailx mail processing system # noqa fqcn[action-core]
+  ansible.builtin.yum:
     name: mailx
     state: present
 
 - name: Disable mailx inbuilt SMTP relay
-  replace:
+  ansible.builtin.replace:
     path: /etc/mail.rc
     regexp: '^(set smtp=.*)'
     replace: '#\1'
 
 - name: Configure Postfix mail transfer agent
-  template:
+  ansible.builtin.template:
     src: main.cf.j2
     dest: "{{ postfix_config_path }}"
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   notify:
     - Restart Postfix service
 
 - name: Flush handlers
-  meta: flush_handlers
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
These changes introduce significant refactoring improvements to the `deploy` role:

- Add descriptive names to plays
- Target multiple paths in sefcontext module task when setting SELinux file contexts
- Use `changed_when` to indicate when non-idempotent tasks (e.g. `command` and `shell`) result in a change or not
- Use fully qualified collection names (FQCNs) for all tasks
- Quote octal numbers (e.g. '0755') to ensure consistent behaviour and avoid failures in loops and other circumstances
- Simplify `set_fact` domain suffix expressions and reduce code duplication
- Add Ansible Lint configuration for linting plays in pipeline jobs
- Replace standalone external roles with `companieshouse.general` collection
- Bump all external collection versions