### PR TITLE
Refactor security group rules

### DIFF
--- a/groups/ois/instance.tf
+++ b/groups/ois/instance.tf
@@ -12,49 +12,49 @@ resource "aws_security_group" "common" {
   name   = "common-${local.common_resource_name}"
   vpc_id = data.aws_vpc.heritage.id
 
-  ingress {
-    description     = "Allow SSH connectivity for application deployments"
-    from_port       = 22
-    to_port         = 22
-    protocol        = "TCP"
-    prefix_list_ids = [data.aws_ec2_managed_prefix_list.shared_services_management.id]
-  }
-
-  dynamic "ingress" {
-    for_each = var.tuxedo_services
-    iterator = service
-    content {
-      description = "Allow CHIPS connectivity for Tuxedo ${upper(service.key)} services"
-      from_port   = service.value
-      to_port     = service.value
-      protocol    = "TCP"
-      cidr_blocks = [var.chips_cidr]
-    }
-  }
-
-  dynamic "ingress" {
-    for_each = var.tuxedo_services
-    iterator = service
-    content {
-      description = "Allow frontend Tuxedo connectivity for Tuxedo ${upper(service.key)} services"
-      from_port   = service.value
-      to_port     = service.value
-      protocol    = "TCP"
-      cidr_blocks = data.aws_subnet.application[*].cidr_block
-    }
-  }
-
-  egress {
-    description = "Allow outbound traffic"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags = merge(local.common_tags, {
     Name = "common-${local.common_resource_name}"
   })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "admin_ingress" {
+  security_group_id = aws_security_group.common.id
+  description       = "Allow SSH connectivity for application deployments"
+  prefix_list_id    = data.aws_ec2_managed_prefix_list.shared_services_management.id
+  from_port         = 22
+  to_port           = 22
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "chips_ingress" {
+  for_each = var.tuxedo_services
+
+  security_group_id = aws_security_group.common.id
+  description       = "Allow CHIPS connectivity for Tuxedo ${upper(each.key)} services"
+  cidr_ipv4         = var.chips_cidr
+  from_port         = each.value
+  to_port           = each.value
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "chl_tuxedo_ingress" {
+  for_each = {
+    for rule in local.chl_tuxedo_security_group_rules : "${rule.service}-${rule.port}-${rule.cidr_ipv4}" => rule
+  }
+
+  security_group_id = aws_security_group.common.id
+  description       = "Allow CHL Tuxedo connectivity for Tuxedo ${upper(each.value.service)} services"
+  cidr_ipv4         = each.value.cidr_ipv4
+  from_port         = each.value.port
+  to_port           = each.value.port
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all_egress" {
+  security_group_id = aws_security_group.common.id
+  description       = "Allow all outbound traffic"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
 }
 
 resource "aws_instance" "ois" {

--- a/groups/ois/locals.tf
+++ b/groups/ois/locals.tf
@@ -40,4 +40,14 @@ locals {
   kms_key_administrator_arns = concat(tolist(data.aws_iam_roles.sso_administrator.arns), [data.aws_iam_user.concourse.arn])
 
   logs_kms_key_id = data.vault_generic_secret.kms_keys.data["logs"]
+
+  chl_tuxedo_security_group_rules = flatten([
+    for service_name, port_number in var.tuxedo_services : [
+      for cidr_block in data.aws_subnet.application[*].cidr_block : {
+        service   = service_name
+        port      = port_number
+        cidr_ipv4 = cidr_block
+      }
+    ]
+  ])
 }


### PR DESCRIPTION
This change replaces all inline `ingress` and `egress` security group rules with `aws_vpc_security_group_ingress_rule` and `aws_vpc_security_group_egress_rule` resources.