### PR TITLE
Increase default log retention period

### DIFF
--- a/groups/ois/profiles/heritage-live-eu-west-2/live/vars
+++ b/groups/ois/profiles/heritage-live-eu-west-2/live/vars
@@ -40,5 +40,5 @@ tuxedo_log_groups = {
   ]
 }
 
-default_log_retention_in_days = 30
+default_log_retention_in_days = 90
 

--- a/groups/ois/variables.tf
+++ b/groups/ois/variables.tf
@@ -28,7 +28,7 @@ variable "chips_cidr" {
 variable "default_log_retention_in_days" {
   type        = number
   description = "The default log retention period in days to be used for CloudWatch log groups."
-  default     = 7
+  default     = 30
 }
 
 variable "dns_zone_suffix" {


### PR DESCRIPTION
This update sets a default log retention period of `30` days for log groups in the `development` and `staging` environments, and `90` days for those in the `live` environment.

Resolves: `DVOP-4503`,